### PR TITLE
Lock web-auth/webauthn-lib to ^4.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ramsey/uuid": "^4.0",
         "symfony/psr-http-message-bridge": "^2.0",
         "web-auth/webauthn-lib": "^3.3",
-        "thecodingmachine/safe": "^1.3.3"
+        "thecodingmachine/safe": "^1.3.3",
+        "web-auth/webauthn-lib": "^4.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.2",

--- a/src/WebAuthn/AuthenticatorSelectionCriteria.php
+++ b/src/WebAuthn/AuthenticatorSelectionCriteria.php
@@ -7,7 +7,7 @@ use Webauthn\AuthenticatorSelectionCriteria as WebAuthnAuthenticatorSelectionCri
 
 class AuthenticatorSelectionCriteria extends WebAuthnAuthenticatorSelectionCriteria
 {
-    private ?string $residentKey = null;
+    public ?string $residentKey = null;
 
     /**
      * Sets the Resident Key variable.


### PR DESCRIPTION
https://github.com/web-auth/webauthn-lib/commit/760dda5f64be89bc535120b054b44f349e495a79#diff-174de8e689e66abff1a5a4abf1bc53e5624c16d43bbbf7399327b7c45a7086fcR43-R45

webauthn-lib had a BC break in a minor. Hence we need to lock it to 4.7 up